### PR TITLE
use const for props in default components

### DIFF
--- a/src/lib/components/DefaultElement.svelte
+++ b/src/lib/components/DefaultElement.svelte
@@ -3,7 +3,13 @@
 <script lang="ts">
 	import type { Element } from 'slate';
 
-	export let element: Element;
+	export const element: Element = {
+		children: [
+			{
+				text: "example",
+			}
+		]
+	}
 	export let isInline: boolean;
 	export let isVoid: boolean;
 	export let contenteditable: boolean;

--- a/src/lib/components/DefaultElement.svelte
+++ b/src/lib/components/DefaultElement.svelte
@@ -6,7 +6,7 @@
 	export const element: Element = {
 		children: [
 			{
-				text: "example",
+				text: "default",
 			}
 		]
 	}

--- a/src/lib/components/DefaultElement.svelte
+++ b/src/lib/components/DefaultElement.svelte
@@ -3,13 +3,8 @@
 <script lang="ts">
 	import type { Element } from 'slate';
 
-	export const element: Element = {
-		children: [
-			{
-				text: "default",
-			}
-		]
-	}
+	// svelte-ignore unused-export-let
+	export let element: Element;
 	export let isInline: boolean;
 	export let isVoid: boolean;
 	export let contenteditable: boolean;

--- a/src/lib/components/DefaultLeaf.svelte
+++ b/src/lib/components/DefaultLeaf.svelte
@@ -3,7 +3,9 @@
 <script lang="ts">
 	import type { Text } from 'slate';
 
-	export let leaf: Text;
+	export const leaf: Text = {
+		text: "example",
+	};
 </script>
 
 <span data-slate-leaf="true"><slot /></span>

--- a/src/lib/components/DefaultLeaf.svelte
+++ b/src/lib/components/DefaultLeaf.svelte
@@ -4,7 +4,7 @@
 	import type { Text } from 'slate';
 
 	export const leaf: Text = {
-		text: "example",
+		text: "default",
 	};
 </script>
 

--- a/src/lib/components/DefaultLeaf.svelte
+++ b/src/lib/components/DefaultLeaf.svelte
@@ -3,9 +3,8 @@
 <script lang="ts">
 	import type { Text } from 'slate';
 
-	export const leaf: Text = {
-		text: "default",
-	};
+	// svelte-ignore unused-export-let
+	export let leaf: Text;
 </script>
 
 <span data-slate-leaf="true"><slot /></span>


### PR DESCRIPTION
The `element` and `leaf` props in `DefaultElement` and `DefaultLeaf` respectively were causing warnings because they were unused vars.

I changed them to const and set default values.