### PR TITLE
Do not dispatch value change even on selection only changes.

### DIFF
--- a/src/lib/components/Slate.svelte
+++ b/src/lib/components/Slate.svelte
@@ -141,7 +141,13 @@
 	function onChange() {
 		selection = editor.selection;
 		value = editor.children;
-		dispatch('value', value);
+
+    const isValueChange = editor.operations.some(op => 'set_selection' !== op.type);
+
+    if (isValueChange) {
+		  dispatch('value', value);
+    }
+
 		dispatch('selection', selection);
 	}
 	EDITOR_TO_ON_CHANGE.set(editor, onChange);


### PR DESCRIPTION
I was getting a ton of "value" events when it was only the selection being modified. This corrects that behavior. There's still a duplicate "value" event being dispatched but that's a separate issue so I didn't address it here.

This fix was copied directly from Slates doc pages [here](https://docs.slatejs.org/walkthroughs/06-saving-to-a-database)